### PR TITLE
Add "micro" type to AddToCartButton and integrate with story page

### DIFF
--- a/app/(shop)/stories/[story]/page.tsx
+++ b/app/(shop)/stories/[story]/page.tsx
@@ -17,6 +17,7 @@ import { Story } from '@/components/story';
 import { Price } from '@/components/price';
 import { Metadata } from 'next';
 import { WithContext, Article, Product as ProductSchema } from 'schema-dts';
+import { AddToCartButton } from '@/components/cart/add-to-cart-button';
 
 const fetchData = async (path: string) => {
     const response = await apiRequest(FetchStoryDocument, { path });
@@ -120,6 +121,19 @@ export default async function StoryPage(props: StoriesProps) {
                     <span className="text-sm font-bold">
                         <Price price={variant.defaultPrice} />
                     </span>
+                </div>
+                <div className="ml-auto self-center">
+                    <AddToCartButton
+                        type="micro"
+                        input={{
+                            sku: variant.sku!,
+                            image: variant.firstImage?.variants?.[0],
+                            price: variant.defaultPrice!,
+                            variantName: variant.name!,
+                            productName: '',
+                            quantity: 1,
+                        }}
+                    />
                 </div>
             </div>
         );

--- a/components/cart/add-to-cart-button.tsx
+++ b/components/cart/add-to-cart-button.tsx
@@ -4,7 +4,7 @@ import clsx from 'classnames';
 import { CartItemInput } from '@/use-cases/contracts/cart';
 import { useCart } from './cart-provider';
 
-type AddToCartButtonProps = { type?: string; input: CartItemInput };
+type AddToCartButtonProps = { type?: 'default' | 'micro'; input: CartItemInput };
 
 export const AddToCartButton = ({ input, type = 'default' }: AddToCartButtonProps) => {
     const { isLoading, onUpdateCart } = useCart();


### PR DESCRIPTION
### Description

This PR introduces the following changes:
- Adds a new "micro" type to the `AddToCartButton`, enhancing its flexibility and usability.
- Integrates the updated button into the story page, enabling users to seamlessly add specific product variants directly to their cart.

<img width="1127" alt="image" src="https://github.com/user-attachments/assets/0c6e5954-8407-4dcf-9e16-70d0e48c6283" />

