### PR TITLE
Update environment variable for Crystallize tenant identifier

### DIFF
--- a/utils/api-request.ts
+++ b/utils/api-request.ts
@@ -2,7 +2,7 @@ import { print } from 'graphql';
 
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
-const apiEndpoint = `https://api.crystallize.com/${process.env.CRYSTALLIZE_TENANT_IDENTIFIER}/discovery`;
+const apiEndpoint = `https://api.crystallize.com/${process.env.NEXT_PUBLIC_CRYSTALLIZE_TENANT_IDENTIFIER}/discovery`;
 
 export const apiRequest = async <TResult, TVariables = {}>(
     query: TypedDocumentNode<TResult, TVariables>,


### PR DESCRIPTION
Updated the environment variable name from `CRYSTALLIZE_TENANT_IDENTIFIER` to `NEXT_PUBLIC_CRYSTALLIZE_TENANT_IDENTIFIER` to comply with frontend naming conventions. Ensures the variable is correctly exposed in the client-side application.